### PR TITLE
Fix -  EventEmitter - Listener List Cleanup Bug

### DIFF
--- a/src/events/EventEmitter.js
+++ b/src/events/EventEmitter.js
@@ -180,8 +180,14 @@ export class EventEmitter {
             listener.onEvent(type, event);
         }
 
+        // If removeListener was called during event emission and removed all 
+        // listeners for this event type, we need to check if listenerList is 
+        // the same as the one in the map before deleting it to avoid deleting a
+        // new listener list that was added during event emission.
         if (listenerList.length === 0) {
-            this.#listeners.delete(type);
+            if (this.#listeners.get(type) === listenerList) {
+                this.#listeners.delete(type);
+            }
         }
     }
 

--- a/tests/events/EventEmitter.test.js
+++ b/tests/events/EventEmitter.test.js
@@ -370,5 +370,41 @@ describe("EventEmitter", () => {
             expect(calls).toEqual(["first", "addedDuringEmit"]);
         });
 
+
+        test("listener isn't accidentally removed during emit", () => {
+            const emitter = new EventEmitter();
+            let calls = [];
+
+            const callbackB = () => {
+                calls.push("B");
+            };
+
+            const callbackA = () => {
+                calls.push("A");
+                // This will remove callbackA from the live list, then it will 
+                // delete the event type from the map.
+                emitter.removeListener("tick", callbackA);
+
+                // This will create a new listener list for the event type.
+                emitter.addListener("tick", callbackB);
+
+                // Once emit continues, it will detect that the listener list it
+                // grabbed is now empty, so it will try to delete the event type 
+                // from the map again.
+            };
+
+            emitter.addListener("tick", callbackA);
+
+            emitter.emit("tick", {});
+            expect(calls).toEqual(["A"]);
+            expect(emitter.getListenerCount("tick")).toBe(1);
+
+            calls = []; // Reset calls
+            emitter.emit("tick", {});
+            expect(calls).toEqual(["B"]);
+            expect(emitter.getListenerCount("tick")).toBe(1);
+
+        });
+
     });
 });

--- a/tests/events/EventEmitter.test.js
+++ b/tests/events/EventEmitter.test.js
@@ -389,8 +389,8 @@ describe("EventEmitter", () => {
                 emitter.addListener("tick", callbackB);
 
                 // Once emit continues, it will detect that the listener list it
-                // grabbed is now empty, so it will try to delete the event type 
-                // from the map again.
+                // grabbed is now empty, so it could try to delete the event 
+                // type from the map again.
             };
 
             emitter.addListener("tick", callbackA);


### PR DESCRIPTION
This fix addresses an edge case during `emit` where a listener could remove itself (or otherwise empty the current listener array), then add a new listener for the same event type, causing the map in `EventEmitter` to point to a new array while `emit` still holds a reference to the old one. Previously, the final cleanup could delete the new array by mistake. The solution adds an identity guard before cleanup so the emitter only deletes the listener list when the map still references the exact same array instance that `emit` started with, preventing accidental removal of newly added listeners while preserving normal cleanup behavior.