### PR TITLE
EventEmitter - Error Handling

### DIFF
--- a/src/events/EventEmitter.js
+++ b/src/events/EventEmitter.js
@@ -171,7 +171,7 @@ export class EventEmitter {
 
             if (listener.once) {
                 // Remove before callback invocation so 'once' remains correct
-                // for re-entrant emits and thrown callbacks.
+                // for re-entrant emits.
                 const liveIndex = listenerList.indexOf(listener);
                 if (liveIndex !== -1) {
                     listenerList.splice(liveIndex, 1);

--- a/src/events/EventEmitter.js
+++ b/src/events/EventEmitter.js
@@ -154,6 +154,7 @@ export class EventEmitter {
      * with the given event object.
      * @param {*} type - The event type.
      * @param {*} event - The event object to pass to listeners.
+     * @throws {AggregateError} Throws an AggregateError if listeners throw errors during event emission.
      */
     emit(type, event) {
         const listenerList = this.#listeners.get(type);
@@ -164,6 +165,7 @@ export class EventEmitter {
         // Use a shallow copy of the listener list to allow listeners to 
         // manipulate the list during event emission without affecting iteration.
         const snapshot = listenerList.slice();
+        const errors = [];
         for (let i = 0; i < snapshot.length; i++) {
             const listener = snapshot[i];
 
@@ -176,17 +178,25 @@ export class EventEmitter {
                 }
             }
 
-            listener.onEvent(type, event);
+            try {
+                listener.onEvent(type, event);
+            } catch (error) {
+                errors.push(error);
+            }
         }
 
-        // If removeListener was called during event emission and removed all 
-        // listeners for this event type, we need to check if listenerList is 
-        // the same as the one in the map before deleting it to avoid deleting a
-        // new listener list that was added during event emission.
-        if (listenerList.length === 0) {
-            if (this.#listeners.get(type) === listenerList) {
-                this.#listeners.delete(type);
-            }
+        // If removeListener was called during event emission, this event type 
+        // may have already been removed, then readded to the map as a new 
+        // array. Double-check before deleting the listener list to avoid 
+        // accidental deletion of a new listener list.
+        if (listenerList.length === 0 && this.#listeners.get(type) === listenerList) {
+            this.#listeners.delete(type);
+        }                    
+
+        // Throw an aggregate error after all listeners have been invoked. This 
+        // also ensures that the listener list is properly cleaned up.
+        if (errors.length > 0) {
+            throw new AggregateError(errors, `Errors occurred while emitting event: ${type}`);
         }
     }
 

--- a/src/events/EventEmitter.js
+++ b/src/events/EventEmitter.js
@@ -168,9 +168,8 @@ export class EventEmitter {
             const listener = snapshot[i];
 
             if (listener.once) {
-                // We have the exact listener instance from the snapshot, so we 
-                // can directly find and remove it from the live listener list 
-                // instead of calling removeListener.
+                // Remove before callback invocation so 'once' remains correct
+                // for re-entrant emits and thrown callbacks.
                 const liveIndex = listenerList.indexOf(listener);
                 if (liveIndex !== -1) {
                     listenerList.splice(liveIndex, 1);

--- a/tests/events/EventEmitter.test.js
+++ b/tests/events/EventEmitter.test.js
@@ -259,7 +259,7 @@ describe("EventEmitter", () => {
         });
     });
 
-    // MARK - off() Tests ------------------------------------------------------
+    // MARK: - off() Tests ------------------------------------------------------
     describe("off(type, callback, owner)", () => {
         test("calls removeListener", () => {
             const emitter = new EventEmitter();

--- a/tests/events/EventEmitter.test.js
+++ b/tests/events/EventEmitter.test.js
@@ -435,7 +435,7 @@ describe("EventEmitter", () => {
         test("once listener is removed even if callback throws", () => {
             const emitter = new EventEmitter();
             const callback = () => {
-                throw new Error("listener failure");;
+                throw new Error("listener failure");
             };
 
             emitter.once("tick", callback);

--- a/tests/events/EventEmitter.test.js
+++ b/tests/events/EventEmitter.test.js
@@ -2,6 +2,7 @@ import { EventEmitter } from "../../src/events/EventEmitter.js";
 import { expect, jest } from "@jest/globals";
 
 describe("EventEmitter", () => {
+    // MARK: - addListener() Tests ---------------------------------------------
     describe("addListener(type, callback, owner, once)", () => {
         test("throws when callback is not a function", () => {
             const emitter = new EventEmitter();
@@ -69,6 +70,7 @@ describe("EventEmitter", () => {
         });
     });
 
+    // MARK: - removeListener() Tests ------------------------------------------
     describe("removeListener(type, callback, owner)", () => {
         test("returns false when event type has no listeners", () => {
             const emitter = new EventEmitter();
@@ -137,6 +139,7 @@ describe("EventEmitter", () => {
         });
     });
 
+    // MARK: - removeAllListeners() Tests --------------------------------------
     describe("removeAllListeners(type)", () => {
         test("clears all event types when type is omitted", () => {
             const emitter = new EventEmitter();
@@ -171,6 +174,7 @@ describe("EventEmitter", () => {
         });
     });
 
+    // MARK: - hasListener() Tests ---------------------------------------------
     describe("hasListener(type, callback, owner)", () => {
         test("returns true only for exact callback-owner match", () => {
             const emitter = new EventEmitter();
@@ -185,6 +189,7 @@ describe("EventEmitter", () => {
         });
     });
 
+    // MARK: - getListenerCount() Tests ----------------------------------------
     describe("getListenerCount(type)", () => {
         test("returns zero for unknown event type", () => {
             const emitter = new EventEmitter();
@@ -202,6 +207,7 @@ describe("EventEmitter", () => {
         });
     });
 
+    // MARK: - getListenerTypes() Tests ----------------------------------------
     describe("getListenerTypes()", () => {
         test("returns all event types that currently have listeners", () => {
             const emitter = new EventEmitter();
@@ -223,6 +229,7 @@ describe("EventEmitter", () => {
         });
     });
 
+    // MARK: - on() Tests ------------------------------------------------------
     describe("on(type, callback, owner)", () => {
         test("calls addListener with once=false", () => {
             const emitter = new EventEmitter();
@@ -237,6 +244,7 @@ describe("EventEmitter", () => {
         });
     });
 
+    // MARK: - once() Tests ----------------------------------------------------
     describe("once(type, callback, owner)", () => {
         test("calls addListener with once=true", () => {
             const emitter = new EventEmitter();
@@ -251,6 +259,7 @@ describe("EventEmitter", () => {
         });
     });
 
+    // MARK - off() Tests ------------------------------------------------------
     describe("off(type, callback, owner)", () => {
         test("calls removeListener", () => {
             const emitter = new EventEmitter();
@@ -266,6 +275,7 @@ describe("EventEmitter", () => {
         });
     });
 
+    // MARK: - emit() Tests ----------------------------------------------------
     describe("emit(type, event)", () => {
         test("returns silently when event type has no listeners", () => {
             const emitter = new EventEmitter();
@@ -424,16 +434,46 @@ describe("EventEmitter", () => {
 
         test("once listener is removed even if callback throws", () => {
             const emitter = new EventEmitter();
-            const error = new Error("listener failure");
             const callback = () => {
-                throw error;
+                throw new Error("listener failure");;
             };
 
             emitter.once("tick", callback);
 
-            expect(() => emitter.emit("tick", {})).toThrow(error);
+            expect(() => emitter.emit("tick", {})).toThrow(AggregateError);
             expect(emitter.getListenerCount("tick")).toBe(0);
+            expect(emitter.getListenerTypes()).toEqual([]);
             expect(() => emitter.emit("tick", {})).not.toThrow();
+        });
+
+        test("emits to all listeners even if some throw errors", () => {
+            const emitter = new EventEmitter();
+            const calls = [];
+
+            const callbackA = () => {
+                calls.push("A");
+                throw new Error("listener A failure");
+            };
+
+            const callbackB = () => {
+                calls.push("B");
+                throw new Error("listener B failure");
+            };
+
+            emitter.addListener("tick", callbackA);
+            emitter.addListener("tick", callbackB);
+
+            expect(() => emitter.emit("tick", {})).toThrow(AggregateError);
+            expect(calls).toEqual(["A", "B"]);
+
+            try {
+                emitter.emit("tick", {});
+            } catch (error) {
+                expect(error).toBeInstanceOf(AggregateError);
+                expect(error.errors).toHaveLength(2);
+                expect(error.errors[0].message).toBe("listener A failure");
+                expect(error.errors[1].message).toBe("listener B failure");
+            }
         });
 
     });

--- a/tests/events/EventEmitter.test.js
+++ b/tests/events/EventEmitter.test.js
@@ -406,5 +406,35 @@ describe("EventEmitter", () => {
 
         });
 
+        test("once listener is not called again during re-entrant emit", () => {
+            const emitter = new EventEmitter();
+            const calls = [];
+
+            const callback = () => {
+                calls.push("once");
+                emitter.emit("tick", {});
+            };
+
+            emitter.once("tick", callback);
+            emitter.emit("tick", {});
+
+            expect(calls).toEqual(["once"]);
+            expect(emitter.getListenerCount("tick")).toBe(0);
+        });
+
+        test("once listener is removed even if callback throws", () => {
+            const emitter = new EventEmitter();
+            const error = new Error("listener failure");
+            const callback = () => {
+                throw error;
+            };
+
+            emitter.once("tick", callback);
+
+            expect(() => emitter.emit("tick", {})).toThrow(error);
+            expect(emitter.getListenerCount("tick")).toBe(0);
+            expect(() => emitter.emit("tick", {})).not.toThrow();
+        });
+
     });
 });


### PR DESCRIPTION
## Description
Added error handling to `EventEmitter.emit(type, event)`. It now aggregates the errors and throws them at the end of the emit call. This ensures two things:
1. All event listeners are invoked during the event emission process, regardless of errors thrown.
2. Listener lists are properly cleaned up.

Also added tests to handle edge cases and errors.