### PR TITLE
Feature #45 - Add Event-Driven Render Scheduling Support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ## Addresses
-- ISSUE_NUMBER
+- Story: NUMBER
 
 ## Description
 <!-- Description of the change -->

--- a/src/core/canvas-app/CanvasApp.js
+++ b/src/core/canvas-app/CanvasApp.js
@@ -63,6 +63,19 @@ export class CanvasApp {
         this.#safeCall(() => this.onResume());
     }
 
+    refresh() {
+        const isNotStopped = !this.isStopped();
+        const isFrameRequested = this.#isFrameRequested();
+        const isDocumentHidden = document.hidden;
+
+        if (isNotStopped || isFrameRequested || isDocumentHidden) {
+            return;
+        }
+
+        this.#lastFrameTime = performance.now();
+        this.#animationFrameId = requestAnimationFrame(this.#tick);
+    }
+
     destroy() {
         if (this.isDestroying() || this.isDestroyed()) {
             return;
@@ -200,9 +213,13 @@ export class CanvasApp {
     }
 
     // MARK: - frame management
+    #isFrameRequested() {
+        return this.#animationFrameId !== null;
+    }
+
     #requestFrame() {
         const isNotRunning = !this.isRunning();
-        const isFrameRequested = this.#animationFrameId !== null;
+        const isFrameRequested = this.#isFrameRequested();
         const isDocumentHidden = document.hidden;
 
         if (isNotRunning || isFrameRequested || isDocumentHidden) {

--- a/src/core/canvas-app/CanvasAppUpdateType.js
+++ b/src/core/canvas-app/CanvasAppUpdateType.js
@@ -1,9 +1,0 @@
-// This feature is scheduled for a different story:
-// - https://github.com/jlstendebach/canvas-engine/issues/42
-// However, I have decided to implement this enum now as I feel like I might 
-// forget these names. Subject to change.
-export const CanvasAppUpdateType = Object.freeze({
-    CONTINUOUS: 1,
-    EVENT_DRIVEN: 2,
-    ONE_TIME: 3
-});


### PR DESCRIPTION
## Addresses
- Story: #45

## Description
Introduces support for event-driven rendering within the `CanvasApp` lifecycle via a new public `refresh()` method.

By leveraging the application's existing state machine and internal frame mechanics, this implementation allows users to cleanly request a single animation frame while the application remains `STOPPED`. This eliminates the need for a continuous `requestAnimationFrame` loop in non-game contexts (such as static charts, UI elements, or event-driven simulations) while still safely hooking into the browser's native rendering queue.
